### PR TITLE
Add further documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This repository contains the scripts and data used to bootstrap a new translation of the Python documentation.
 
+## Why python-docs-bootstrapper?
+
+...
+
 ## Installation
 
 ```bash

--- a/bootstrapper/data/README.md
+++ b/bootstrapper/data/README.md
@@ -9,6 +9,15 @@ Hello! This is the repository of the {{translation.language}} translation of the
 - [Other Translations](https://github.com/orgs/python/repositories?q=python-docs) (see how other translations are doing it)
 - [Python Docs Discord Server](https://discord.com/invite/sMWqvzXvde) (especially the `#translations` channel)
 
+**Tips for the maintainers:**
+
+...
+
+**The ultimate checklist to get you started:**
+
+...
+
+
 ## Documentation Contribution Agreement
 Python's documentation is maintained using a global network of volunteers. By posting this project on Transifex, Github, and other public places, and inviting you to participate, we are proposing an agreement that you will provide your improvements to Python's documentation or the translation of Python's documentation for the PSF's use under the CC0 license (available at https://creativecommons.org/publicdomain/zero/1.0/legalcode). In return, you may publicly claim credit for the portion of the translation you contributed and if your translation is accepted by the PSF, you may (but are not required to) submit a patch including an appropriate annotation in the Misc/ACKS or TRANSLATORS file. Although nothing in this Documentation Contribution Agreement obligates the PSF to incorporate your textual contribution, your participation in the Python community is welcomed and appreciated.
 


### PR DESCRIPTION
- Add "Why use python-docs-bootstrapper" section in the README
- Add tips and checklist for translation maintainers